### PR TITLE
Add note about logout KDE 4 instructions for KDE 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ bindsym $mod+Shift+e exec --no-startup-id qdbus org.kde.ksmserver /KSMServer org
 bindsym $mod+Shift+e exec --no-startup-id qdbus-qt5 org.kde.ksmserver /KSMServer org.kde.KSMServerInterface.logout -1 -1 -1
 ```
 
-*(Note: This seems to not work on some distros.)*
+*Note: With some distros, even if you have KDE 5 and Qt 5, the above line may not work and would require calling ```qdbus``` instead of ```qdbus-qt5```, as shown under KDE 4.*
 
 ---
 </details>


### PR DESCRIPTION
Add note about logout KDE 4 instructions for KDE 5 on some distros where it doesn't work.

On Debian stable, even with KDE and Qt 5, the KDE 4 instructions work while the KDE 5 instructions do not.

I only found this out from [KDE's Userbase Wiki](https://userbase.kde.org/Tutorials/Using_Other_Window_Managers_with_Plasma#DBus), where they use what is the KDE 4 instructions on this repo:
`qdbus org.kde.ksmserver /KSMServer org.kde.KSMServerInterface.logout -1 -1 -1`

I don't know what other distros using `qtbus-qt5` won't work, so I don't know if this applies to all other distros than Debian stable.
